### PR TITLE
Set number of rocket workers to 1

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,4 +18,4 @@ RUN apt-get update -y && \
     apt-get install -y libpq-dev
 
 COPY --from=builder /book-db/target/release/book-db book-db
-CMD ["/bin/bash", "-c", "ROCKET_PORT=$PORT ROCKET_DATABASES={book_db={url=$DATABASE_URL}} ./book-db"]
+CMD ["/bin/bash", "-c", "ROCKET_WORKERS=1 ROCKET_PORT=$PORT ROCKET_DATABASES={book_db={url=$DATABASE_URL}} ./book-db"]


### PR DESCRIPTION
Currently, the application runs fine locally, but while running in Heroku the application crashes due to too many connections to postgres (max 20 for free plan). It seems like the number of connections in the connection pool defaults to same as the number of rocket workers (threads, concurrent connections, or something like that). So, let's try to limit the number of workers
