### PR TITLE
Set ROCKET_ADDRESS to bind to 0.0.0.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,4 +18,4 @@ RUN apt-get update -y && \
     apt-get install -y libpq-dev
 
 COPY --from=builder /book-db/target/release/book-db book-db
-CMD ["/bin/bash", "-c", "ROCKET_WORKERS=1 ROCKET_PORT=$PORT ROCKET_DATABASES={book_db={url=$DATABASE_URL}} ./book-db"]
+CMD ["/bin/bash", "-c", "ROCKET_ADDRESS=0.0.0.0 ROCKET_WORKERS=1 ROCKET_PORT=$PORT ROCKET_DATABASES={book_db={url=$DATABASE_URL}} ./book-db"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       PORT: 8000
       DATABASE_URL: "postgres://postgres:password@db/postgres"
-      ROCKET_ADDRESS: "0.0.0.0"
   db:
     image: postgres
     restart: always


### PR DESCRIPTION
By binding to 0.0.0.0 instead of localhost I will let anyone connect as long as network access is available (I think this is required in order to have Heroku connect to it). See: https://nickjanetakis.com/blog/docker-tip-54-fixing-connection-reset-by-peer-or-similar-errors
