### PR TITLE
Append CORS headers to each response

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -46,6 +46,9 @@ async fn delete_book(book_id: i32, db: BookDb) {
     }).await;
 }
 
+#[options("/")]
+async fn cors_preflight() {}
+
 async fn run_db_migrations(rocket: Rocket<Build>) -> Result<Rocket<Build>, Rocket<Build>> {
     embed_migrations!();
     let db = BookDb::get_one(&rocket).await
@@ -73,6 +76,7 @@ async fn main() {
             })
         }))
         .mount("/books", routes![
+            cors_preflight,
             create_book,
             get_books,
             delete_book,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,6 +8,7 @@ mod schema;
 
 use rocket::{Rocket, Build};
 use rocket::fairing::AdHoc;
+use rocket::http::Header;
 use rocket_contrib::json::Json;
 use rocket_contrib::databases::{database, diesel as rocket_contrib_diesel};
 use rocket_contrib_diesel::RunQueryDsl;
@@ -64,6 +65,13 @@ async fn main() {
     rocket::build()
         .attach(BookDb::fairing())
         .attach(AdHoc::try_on_ignite("Database migrations", run_db_migrations))
+        .attach(AdHoc::on_response("CORS Headers", |_request, response| {
+            Box::pin(async move {
+                response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
+                response.set_header(Header::new("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS"));
+                response.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+            })
+        }))
         .mount("/books", routes![
             create_book,
             get_books,


### PR DESCRIPTION
Add a fairing (with on_response hook) to append CORS headers to each response.
In addition, add an OPTIONS path to allow preflight checks.